### PR TITLE
fix(hackathon): backport excavator swing input fixes

### DIFF
--- a/Assets/Machines/Excavator/Scripts/ExcavatorInput.cs
+++ b/Assets/Machines/Excavator/Scripts/ExcavatorInput.cs
@@ -316,7 +316,11 @@ namespace PWRISimulator.ROS
                         if (GetEffectiveJointValue(currentTime, JOINT_SWING, out double swingPos))
                         {
                             joints.swing.actuator.controlType = ControlType.Position;
-                            joints.swing.actuator.controlValue = swingPos;
+                            // Unwrap normalized swingPos (-PI..+PI) to the nearest equivalent
+                            // angle in the internal continuous coordinate used by AGX.
+                            double currentInternal = joints.swing.actuator.CurrentPosition;
+                            double adjusted = swingPos + Math.Round((currentInternal - swingPos) / (2.0 * Math.PI)) * (2.0 * Math.PI);
+                            joints.swing.actuator.controlValue = adjusted;
                         }
                         break;
                     case ControlType.Speed:

--- a/Assets/Machines/Excavator/Scripts/ExcavatorInput.cs
+++ b/Assets/Machines/Excavator/Scripts/ExcavatorInput.cs
@@ -319,7 +319,8 @@ namespace PWRISimulator.ROS
                             // Unwrap normalized swingPos (-PI..+PI) to the nearest equivalent
                             // angle in the internal continuous coordinate used by AGX.
                             double currentInternal = joints.swing.actuator.CurrentPosition;
-                            double adjusted = swingPos + Math.Round((currentInternal - swingPos) / (2.0 * Math.PI)) * (2.0 * Math.PI);
+                            double twoPi = 2.0 * Math.PI;
+                            double adjusted = swingPos + Math.Round((currentInternal - swingPos) / twoPi, MidpointRounding.AwayFromZero) * twoPi;
                             joints.swing.actuator.controlValue = adjusted;
                         }
                         break;


### PR DESCRIPTION
## Summary
- backport `0736df8cfdc9bd87db56e467f22b15de690ea0c1` to unwrap normalized swing commands to the nearest continuous angle
- backport `2df5f6c2da3dc21e79f72093bc398dfdadcd2f0b` to keep the `ExcavatorInput.cs` follow-up change aligned on `hackathon`

## Notes
- both commits cherry-picked cleanly onto `hackathon`
- this branch contains only the two requested backport commits on top of `origin/hackathon`
